### PR TITLE
Feature optimize performance

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -66,6 +66,7 @@ dependencies {
     include(implementation('org.mongodb:mongodb-driver-core:4.11.1'))
     include(implementation('org.mongodb:bson:4.11.1'))
     include(implementation('com.h2database:h2:2.2.224'))
+    include(implementation('org.lz4:lz4-java:1.8.0'))
 
 }
 

--- a/src/main/java/dev/skydynamic/quickbackupmulti/command/MakeCommand.java
+++ b/src/main/java/dev/skydynamic/quickbackupmulti/command/MakeCommand.java
@@ -26,9 +26,10 @@ public class MakeCommand {
 
         @Override
         public void run() {
+            long l = System.currentTimeMillis();
             LOGGER.info("Make Backup thread started...");
             make(commandSource, name, desc);
-            LOGGER.info("Make Backup thread close");
+            LOGGER.info("Make Backup thread close => {}ms", System.currentTimeMillis() - l);
         }
     }
 
@@ -45,7 +46,8 @@ public class MakeCommand {
 //            .executes(it -> makeSaveBackup(it.getSource(), String.valueOf(System.currentTimeMillis()), StringArgumentType.getString(it, "desc"))));
 
     private static int makeSaveBackup(ServerCommandSource commandSource, String name, String desc) {
-        new makeRunnable(commandSource, name, desc).run();
+        Thread.startVirtualThread(new makeRunnable(commandSource, name, desc));
+//        new makeRunnable(commandSource, name, desc).run();
         return 1;
     }
 }

--- a/src/main/java/dev/skydynamic/quickbackupmulti/command/MakeCommand.java
+++ b/src/main/java/dev/skydynamic/quickbackupmulti/command/MakeCommand.java
@@ -46,8 +46,7 @@ public class MakeCommand {
 //            .executes(it -> makeSaveBackup(it.getSource(), String.valueOf(System.currentTimeMillis()), StringArgumentType.getString(it, "desc"))));
 
     private static int makeSaveBackup(ServerCommandSource commandSource, String name, String desc) {
-        Thread.startVirtualThread(new makeRunnable(commandSource, name, desc));
-//        new makeRunnable(commandSource, name, desc).run();
+        new Thread(new makeRunnable(commandSource, name, desc)).start();
         return 1;
     }
 }

--- a/src/main/java/dev/skydynamic/quickbackupmulti/config/ConfigStorage.java
+++ b/src/main/java/dev/skydynamic/quickbackupmulti/config/ConfigStorage.java
@@ -1,18 +1,20 @@
 package dev.skydynamic.quickbackupmulti.config;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Objects;
 
 public class ConfigStorage {
     @Ignore
     public static final ConfigStorage DEFAULT = new ConfigStorage(
-        new ArrayList<>(),
-        "zh_cn",
-        false,
-        "* * 0/4 * * ?",
-        14400,
-        "interval",
-        true,
-        "mongodb://localhost:27017"
+            new ArrayList<>(),
+            "zh_cn",
+            false,
+            "* * 0/4 * * ?",
+            14400,
+            "interval",
+            true,
+            "mongodb://localhost:27017",
+            false
     );
 
     public ArrayList<String> ignoredFiles;
@@ -24,16 +26,18 @@ public class ConfigStorage {
 
     public boolean useInternalDataBase;
     public String mongoDBUri;
+    public boolean useFastHash;
 
     public ConfigStorage(
-        ArrayList<String> IgnoredFiles,
-        String lang,
-        boolean scheduleBackup,
-        String scheduleCron,
-        int scheduleInterval,
-        String scheduleMode,
-        boolean useInternalDataBase,
-        String mongoDBUri) {
+            ArrayList<String> IgnoredFiles,
+            String lang,
+            boolean scheduleBackup,
+            String scheduleCron,
+            int scheduleInterval,
+            String scheduleMode,
+            boolean useInternalDataBase,
+            String mongoDBUri,
+            boolean useFastHash) {
         this.ignoredFiles = IgnoredFiles;
         this.lang = lang;
         this.scheduleBackup = scheduleBackup;
@@ -42,6 +46,7 @@ public class ConfigStorage {
         this.scheduleMode = scheduleMode;
         this.useInternalDataBase = useInternalDataBase;
         this.mongoDBUri = mongoDBUri;
+        this.useFastHash = useFastHash;
     }
 
     public boolean getScheduleBackup() {

--- a/src/main/java/dev/skydynamic/quickbackupmulti/config/QuickBackupMultiConfig.java
+++ b/src/main/java/dev/skydynamic/quickbackupmulti/config/QuickBackupMultiConfig.java
@@ -141,6 +141,12 @@ public class QuickBackupMultiConfig {
         }
     }
 
+    public boolean getUseFastHash() {
+        synchronized (lock) {
+            return configStorage.useFastHash;
+        }
+    }
+
     public void setLang(String lang) {
         synchronized (lock) {
             configStorage.lang = lang;

--- a/src/main/java/dev/skydynamic/quickbackupmulti/utils/MakeUtils.java
+++ b/src/main/java/dev/skydynamic/quickbackupmulti/utils/MakeUtils.java
@@ -2,7 +2,10 @@ package dev.skydynamic.quickbackupmulti.utils;
 
 import dev.morphia.query.filters.Filters;
 import dev.skydynamic.quickbackupmulti.config.Config;
-import dev.skydynamic.quickbackupmulti.storage.*;
+import dev.skydynamic.quickbackupmulti.storage.BackupInfo;
+import dev.skydynamic.quickbackupmulti.storage.DimensionFormat;
+import dev.skydynamic.quickbackupmulti.storage.FileHashes;
+import dev.skydynamic.quickbackupmulti.storage.IndexFile;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.world.ServerWorld;
@@ -15,8 +18,8 @@ import java.io.IOException;
 import java.util.*;
 
 import static dev.skydynamic.quickbackupmulti.QuickBackupMulti.LOGGER;
-import static dev.skydynamic.quickbackupmulti.i18n.Translate.tr;
 import static dev.skydynamic.quickbackupmulti.QuickBackupMulti.getDataBase;
+import static dev.skydynamic.quickbackupmulti.i18n.Translate.tr;
 import static dev.skydynamic.quickbackupmulti.utils.QbmManager.*;
 import static dev.skydynamic.quickbackupmulti.utils.ScheduleUtils.startSchedule;
 import static dev.skydynamic.quickbackupmulti.utils.hash.HashUtils.compareFileHash;
@@ -168,12 +171,14 @@ public class MakeUtils {
                         if (file.getName().equals("DIM1") || file.getName().equals("DIM-1")) {
                             // 如果是文件夹（原版情况下一般只有文件夹了xwx, 但还是要判断）
                             if (dirFile.isDirectory()) {
+                                // 使用DIM的目标文件夹
+                                File dimDestDir = getBackupDir().resolve(name + "/" + file.getName()).toFile();
                                 // 初始化
                                 hashMap = new HashMap<>();
                                 indexMap = new HashMap<>();
                                 for (File dirFile1 : dirFile.listFiles()) {
                                     // 该处同root与别的文件夹
-                                    HashMap<String, Object> resultMap = compareAndIndex(firstBackup, latestBackupName, fileHashedDocument, indexFileDocument, dirFile1, destDir, hashMap, indexMap, indexBackupList);
+                                    HashMap<String, Object> resultMap = compareAndIndex(firstBackup, latestBackupName, fileHashedDocument, indexFileDocument, dirFile1, dimDestDir, hashMap, indexMap, indexBackupList);
                                     hashMap = (HashMap<String, String>) resultMap.get("hash");
                                     indexMap = (HashMap<String, String>) resultMap.get("index");
                                     indexBackupList = (List<String>) resultMap.get("indexBackupList");

--- a/src/main/java/dev/skydynamic/quickbackupmulti/utils/MakeUtils.java
+++ b/src/main/java/dev/skydynamic/quickbackupmulti/utils/MakeUtils.java
@@ -87,7 +87,7 @@ public class MakeUtils {
         List<String> indexBackupList // 索引列表
     ) throws Exception {
         // 获取文件Hash
-        String fileHash = getFileHash(file.toPath());
+        String fileHash = getFileHash(file.toPath(), null);
         // 如果不是第一次备份
         if (!isFirstBackup) {
             // 对比文件Hash

--- a/src/main/java/dev/skydynamic/quickbackupmulti/utils/hash/HashUtils.java
+++ b/src/main/java/dev/skydynamic/quickbackupmulti/utils/hash/HashUtils.java
@@ -1,21 +1,58 @@
 package dev.skydynamic.quickbackupmulti.utils.hash;
 
+import dev.skydynamic.quickbackupmulti.config.Config;
 import dev.skydynamic.quickbackupmulti.storage.FileHashes;
+import net.jpountz.xxhash.XXHashFactory;
 
 import java.io.File;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 
+import static dev.skydynamic.quickbackupmulti.QuickBackupMulti.LOGGER;
+
 public class HashUtils {
 
-    public static String getFileHash(Path file) throws Exception {
-        byte[] fileData = Files.readAllBytes(file);
+    private static final String SHA_256 = "SHA-256";
+    private final static XXHashFactory XX_HASH_FACTORY = XXHashFactory.fastestInstance();
+    private static Boolean useFastHash;
 
-        MessageDigest md = MessageDigest.getInstance("SHA-256");
+    public static String getFileHash(Path file, String algorithm) throws Exception {
+        if (useFastHash == null) {
+            useFastHash = Config.INSTANCE.getUseFastHash();
+            LOGGER.info("Backup UseFastHash => {}", useFastHash);
+        }
+        if (algorithm == null) {
+            algorithm = SHA_256;
+        }
+        byte[] fileData;
+        byte[] digest;
+        if (useFastHash) {
+            String fileName = file.getFileName().toString();
+            boolean isAnvil = fileName.startsWith("r.") && fileName.endsWith(".mca");
+            if (isAnvil) {
+                /*
+                   对于(Anvil)区块文件来说，只需要校验8kB文件头即可得知区块文件是否有变动
+                   区块位置：0 - 4095 每个区块占用4个字节，存储区块位置，未生成则为0填充
+                   区块更新时间戳：4096 - 8191 每个区块占用4个字节，存储区块更新的时间戳
+                 */
+                try (InputStream is = Files.newInputStream(file)) {
+                    fileData = new byte[8192];
+                    is.read(fileData, 0, fileData.length);
+                }
+            } else {
+                fileData = Files.readAllBytes(file);
+            }
+            // 使用高性能非加密哈希算法
+            digest = longToBytes(XX_HASH_FACTORY.hash64().hash(fileData, 0, fileData.length, 0));
+            return bytesToHex(digest);
+        }
+        fileData = Files.readAllBytes(file);
+        MessageDigest md = MessageDigest.getInstance(algorithm);
         md.update(fileData);
-        byte[] digest = md.digest();
-
+        digest = md.digest();
         return bytesToHex(digest);
     }
 
@@ -28,11 +65,19 @@ public class HashUtils {
         StringBuilder hexString = new StringBuilder(2 * hash.length);
         for (byte b : hash) {
             String hex = Integer.toHexString(0xff & b);
-            if(hex.length() == 1) {
+            if (hex.length() == 1) {
                 hexString.append('0');
             }
             hexString.append(hex);
         }
         return hexString.toString();
+    }
+
+    public static byte[] longToBytes(long l) {
+        //分配缓冲区，单位为字节，一个long类型占8个字节，所以分配为8
+        ByteBuffer byteBuffer = ByteBuffer.allocate(Long.SIZE / Byte.SIZE);
+        //参数一为起始位置（不指定默认为0），参数二为所放的值
+        byteBuffer.putLong(0, l);
+        return byteBuffer.array();
     }
 }


### PR DESCRIPTION
1. 大幅优化备份速度和CPU使用率（优化区块文件差异化校验方式，更换高性能摘要算法）
2. 优化使用指令首次备份因备份时间过长导致服务端自动关闭（使用异步） #28
3. 修复增量备份时下界和末地文件存储到错误位置，导致备份的存档损坏并且无法回滚 #34 #32 #23

注：优化备份速度功能为实验性，默认关闭，配置文件useFastHash=true时启用；最好新档使用，理论上可以兼容历史存档回档（未经密集测试）

环境：
i9 13900HX 64G JDK21
存档大小：15.2GB
性能测试：
一、优化前
首次备份
![4cdf3965d54d066c35b6b794d2eb22a](https://github.com/SkyDynamic/QuickBackupM-Fabric/assets/40592682/62d208cc-6f35-4cf9-8ced-cb987f838814)
增量备份
![d15fbb0ec54a5c5b78e2f91689ba0b2](https://github.com/SkyDynamic/QuickBackupM-Fabric/assets/40592682/c8b08f19-3863-425a-b377-16cc1e428149)

二、优化后
首次备份
![b9f0e242e6b6f82b8e0e4efcc7ae3c8](https://github.com/SkyDynamic/QuickBackupM-Fabric/assets/40592682/51cd8c36-c447-4703-80a4-af06217ce040)
增量备份
![77492307c50ecb52c8ed2f521334ab8](https://github.com/SkyDynamic/QuickBackupM-Fabric/assets/40592682/20c6e60f-8061-4086-be53-21e4c1c91f70)